### PR TITLE
ST-9009 【投稿v2】API v2 media対応 - TwitterOAuth - v2 uploadリクエスト修正

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -332,6 +332,7 @@ class TwitterOAuth extends Config
                     'media' => fread($media, $this->chunkSize)
                 ],
                 false,
+                true,
             );
         }
         fclose($media);
@@ -579,7 +580,8 @@ class TwitterOAuth extends Config
         string $host,
         string $path,
         array $parameters,
-        bool $json
+        bool $json,
+        bool $isBinaryMultipart = false
     ) {
         $this->resetLastResponse();
         $this->resetAttemptsNumber();
@@ -593,6 +595,7 @@ class TwitterOAuth extends Config
             $method,
             $parameters,
             $json,
+            $isBinaryMultipart
         );
     }
 
@@ -648,11 +651,12 @@ class TwitterOAuth extends Config
         string $url,
         string $method,
         array $parameters,
-        bool $json
+        bool $json,
+        bool $isBinaryMultipart = false
     ) {
         do {
             $this->sleepIfNeeded();
-            $result = $this->oAuthRequest($url, $method, $parameters, $json);
+            $result = $this->oAuthRequest($url, $method, $parameters, $json, $isBinaryMultipart);
             $response = JsonDecoder::decode($result, $this->decodeJsonAsArray);
             $this->response->setBody($response);
             $this->attempts++;
@@ -689,7 +693,8 @@ class TwitterOAuth extends Config
         string $url,
         string $method,
         array $parameters,
-        bool $json = false
+        bool $json = false,
+        bool $isBinaryMultipart = false
     ) {
         $request = Request::fromConsumerAndToken(
             $this->consumer,
@@ -697,7 +702,9 @@ class TwitterOAuth extends Config
             $method,
             $url,
             $parameters,
-            $json,
+            // jsonに加えて、binary multipartリクエストの場合でもbodyをoauthのsignatureの生成に利用しない
+            // @see https://developer.x.com/en/docs/x-api/v1/media/upload-media/uploading-media/media-best-practices
+            $json || $isBinaryMultipart
         );
         if (array_key_exists('oauth_callback', $parameters)) {
             // Twitter doesn't like oauth_callback as a parameter.
@@ -724,6 +731,7 @@ class TwitterOAuth extends Config
             $authorization,
             $parameters,
             $json,
+            $isBinaryMultipart
         );
     }
 
@@ -780,7 +788,8 @@ class TwitterOAuth extends Config
         string $method,
         string $authorization,
         array $postfields,
-        bool $json = false
+        bool $json = false,
+        bool $isBinaryMultipart = false
     ): string {
         $options = $this->curlOptions();
         $options[CURLOPT_URL] = $url;
@@ -799,6 +808,7 @@ class TwitterOAuth extends Config
                     $options,
                     $postfields,
                     $json,
+                    $isBinaryMultipart
                 );
                 break;
             case 'DELETE':
@@ -903,7 +913,8 @@ class TwitterOAuth extends Config
     private function setPostfieldsOptions(
         array $options,
         array $postfields,
-        bool $json
+        bool $json,
+        bool $isBinaryMultipart = false
     ): array {
         if ($json) {
             $options[CURLOPT_HTTPHEADER][] = 'Content-type: application/json';
@@ -912,7 +923,13 @@ class TwitterOAuth extends Config
                 JSON_THROW_ON_ERROR,
             );
         } else {
-            $options[CURLOPT_POSTFIELDS] = Util::buildHttpQuery($postfields);
+            if ($isBinaryMultipart) {
+                // binary multipartリクエストの場合headerを設定し、postデータをエンコードせず直接設定（X API v2 メディアアップロードの対応）
+                $options[CURLOPT_HTTPHEADER][] = 'Content-type: multipart/form-data';
+                $options[CURLOPT_POSTFIELDS] = $postfields;
+            } else {
+                $options[CURLOPT_POSTFIELDS] = Util::buildHttpQuery($postfields);
+            }
         }
 
         return $options;


### PR DESCRIPTION
X API V2 メディアアップロードの[APPEND](https://docs.x.com/x-api/media/quickstart/media-upload-chunked)リクエストが正常に行えるように以下の修正を行いました
- v2 APPEND リクエストの場合、multipartヘッダーが設定され、postデータがそのまま（エンコードなどせず）設定
- v2 APPEND リクエストの場合、oauth signatureの生成に リクエストのbody を利用しない（これをしない場合400エラーになりました）→ API v2の資料に記載はなさそうですがv1 の資料に[ bodyを含めないよう](https://developer.x.com/en/docs/x-api/v1/media/upload-media/uploading-media/media-best-practices)にと書いてあります 
  <img width="877" alt="image" src="https://github.com/user-attachments/assets/3e162e69-cac2-477e-8a74-7bd8a8213a25" />


上記ができるように既存の関数に`$isBinaryMultipart`引数を追加しました
- すべての場合最後のオプション引数になっているため動作に影響はない想定です→`true`に設定しているのは uploadV2のAPPENDリクエストのみ （masterをチェックアウトしてTwitterOAuth.phpの内容をこちらのPRのものに入れ替えて、投稿v2でメディア付き投稿を投稿することで簡易動作確認済み）


確認していただきたいこと
- 実際内容に問題はなさそうか
