### PR TITLE
【投稿v2】2025/5 XメディアAPIエンドポイントの変更に対応 - TwitterOauth

### DIFF
--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -318,7 +318,7 @@ class TwitterOAuth extends Config
     public function uploadV2(array $parameters = [])
     {
         $initPath = 'media/upload/initialize';
-        $init = $this->http('POST', self::API_V2_HOST, $initPath, $this->mediaInitParametersV2($parameters), false);
+        $init = $this->http('POST', self::API_V2_HOST, $initPath, $this->mediaInitParametersV2($parameters), true);
         // Append
         $segmentIndex = 0;
         $media = fopen($parameters['media'], 'rb');

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -315,10 +315,10 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function uploadV2(array $parameters = [])
+    public function uploadV2MultipleEndpoints(array $parameters = [])
     {
         $initPath = 'media/upload/initialize';
-        $init = $this->http('POST', self::API_V2_HOST, $initPath, $this->mediaInitParametersV2($parameters), true);
+        $init = $this->http('POST', self::API_V2_HOST, $initPath, $this->mediaInitParametersV2MultipleEndpoints($parameters), true);
         // Append
         $segmentIndex = 0;
         $media = fopen($parameters['media'], 'rb');
@@ -360,9 +360,9 @@ class TwitterOAuth extends Config
      *
      * @return array|object
      */
-    public function uploadV2SingleEndpoint($path, array $parameters = [])
+    public function uploadV2($path, array $parameters = [])
     {
-        $init = $this->http('POST', self::API_V2_HOST, $path, $this->mediaInitParametersV2SingleEndpoint($parameters), false);
+        $init = $this->http('POST', self::API_V2_HOST, $path, $this->mediaInitParametersV2($parameters), false);
         // Append
         $segmentIndex = 0;
         $media = fopen($parameters['media'], 'rb');
@@ -547,7 +547,7 @@ class TwitterOAuth extends Config
      *
      * @return array
      */
-    private function mediaInitParametersV2(array $parameters)
+    private function mediaInitParametersV2MultipleEndpoints(array $parameters)
     {
         $return = [
             'media_type' => $parameters['media_type'],
@@ -571,7 +571,7 @@ class TwitterOAuth extends Config
      *
      * @return array
      */
-    private function mediaInitParametersV2SingleEndpoint(array $parameters)
+    private function mediaInitParametersV2(array $parameters)
     {
         $return = [
             'command' => 'INIT',

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -344,9 +344,7 @@ class TwitterOAuth extends Config
             'POST',
             self::API_V2_HOST,
             $finalizePath,
-            [
-                'command' => 'FINALIZE',
-            ],
+            [],
             false,
         );
         return $finalize;

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -308,7 +308,7 @@ class TwitterOAuth extends Config
 
     /**
      * Upload media to api.x.com using X API v2.
-     * Uses multiple endpoints, one for each commands (/init, /append, /finalize).
+     * Uses multiple endpoints, one for each commands (/initialize, /append, /finalize).
      * @see https://docs.x.com/x-api/media/media-upload-initialize
      *
      * @param array  $parameters

--- a/src/TwitterOAuth.php
+++ b/src/TwitterOAuth.php
@@ -308,15 +308,63 @@ class TwitterOAuth extends Config
 
     /**
      * Upload media to api.x.com using X API v2.
+     * Uses multiple endpoints, one for each commands (/init, /append, /finalize).
+     * @see https://docs.x.com/x-api/media/media-upload-initialize
+     *
+     * @param array  $parameters
+     *
+     * @return array|object
+     */
+    public function uploadV2(array $parameters = [])
+    {
+        $initPath = 'media/upload/initialize';
+        $init = $this->http('POST', self::API_V2_HOST, $initPath, $this->mediaInitParametersV2($parameters), false);
+        // Append
+        $segmentIndex = 0;
+        $media = fopen($parameters['media'], 'rb');
+        $mediaId = $init['data']['id'];
+        $appendPath = 'media/upload/' .  $mediaId . '/append';
+        while (!feof($media)) {
+            $this->http(
+                'POST',
+                self::API_V2_HOST,
+                $appendPath,
+                [
+                    'segment_index' => $segmentIndex++,
+                    'media' => fread($media, $this->chunkSize)
+                ],
+                false,
+                true,
+            );
+        }
+        fclose($media);
+        // Finalize
+        $finalizePath = 'media/upload/' .  $mediaId . '/finalize';
+        $finalize = $this->http(
+            'POST',
+            self::API_V2_HOST,
+            $finalizePath,
+            [
+                'command' => 'FINALIZE',
+            ],
+            false,
+        );
+        return $finalize;
+    }
+
+    /**
+     * @deprecated
+     * Upload media to api.x.com using X API v2.
+     * Uses the single /upload endpoint with commands (INIT, APPEND, FINALIZE) specified with the command request parameter.
      *
      * @param string $path
      * @param array  $parameters
      *
      * @return array|object
      */
-    public function uploadV2($path, array $parameters = [])
+    public function uploadV2SingleEndpoint($path, array $parameters = [])
     {
-        $init = $this->http('POST', self::API_V2_HOST, $path, $this->mediaInitParametersV2($parameters), false);
+        $init = $this->http('POST', self::API_V2_HOST, $path, $this->mediaInitParametersV2SingleEndpoint($parameters), false);
         // Append
         $segmentIndex = 0;
         $media = fopen($parameters['media'], 'rb');
@@ -502,6 +550,30 @@ class TwitterOAuth extends Config
      * @return array
      */
     private function mediaInitParametersV2(array $parameters)
+    {
+        $return = [
+            'media_type' => $parameters['media_type'],
+            'total_bytes' => filesize($parameters['media']),
+            'media_category' => $this->getMediaCategory($parameters['media_type']),
+        ];
+        if (isset($parameters['additional_owners'])) {
+            $return['additional_owners'] = $parameters['additional_owners'];
+        }
+        if (isset($parameters['media_category'])) {
+            $return['media_category'] = $parameters['media_category'];
+        }
+        return $return;
+    }
+
+    /**
+     * Private method to get params for upload media chunked init.
+     * Twitter docs: https://docs.x.com/x-api/media/quickstart/media-upload-chunked#step-1-%3A-post-media%2Fupload-init
+     *
+     * @param array  $parameters
+     *
+     * @return array
+     */
+    private function mediaInitParametersV2SingleEndpoint(array $parameters)
     {
         $return = [
             'command' => 'INIT',


### PR DESCRIPTION
## 変更内容
新しいXメディアアップロードエンドポイントに対応したupload機能を追加しました
- Xの新APIで障害が発生する傾向があるため旧やり方に戻しやすいように新規関数の追加で対応することにしました

古いパッケージでLintが落ちていますが修正が少し難しい＋もう少しでv2が廃止されるため許容したいと考えています 🙏 
→ [前回のPRも同様のエラーが出ていました](https://github.com/socialdog-inc/twitteroauth/pull/6#issuecomment-2683554517)

## 影響範囲・懸念点
未使用関数の追加のみのため動作に影響はない想定です

→ 動作確認は今回追加した関数を利用するように修正するPRでお願いしたいです 🙏 
（一応軽くローカルで確認してみましたら動いていそうです）

## 確認してほしいこと
- 修正内容に問題はなさそうか


## 関連URL
https://docs.x.com/x-api/media/media-upload
https://devcommunity.x.com/t/media-upload-endpoints-update-and-extended-migration-deadline/241818



